### PR TITLE
[NCLSUP-40] Fix logic for keycloak `refreshRequired`

### DIFF
--- a/src/main/java/org/jboss/pnc/cleaner/auth/DefaultKeycloakServiceClient.java
+++ b/src/main/java/org/jboss/pnc/cleaner/auth/DefaultKeycloakServiceClient.java
@@ -87,9 +87,14 @@ public class DefaultKeycloakServiceClient implements KeycloakServiceClient {
     }
 
     private boolean refreshRequired() {
-        if (expiresAt.isAfter(Instant.now().plus(serviceTokenRefreshIfExpiresInSeconds, ChronoUnit.SECONDS))) {
+
+        if (expiresAt == null) {
+            // if we accidentally call this method before expiresAt is set, then we obviously need to get a new token
             return true;
         }
-        return false;
+
+        // make sure the token is still valid 'serviceTokenRefreshIfExpiresInSeconds' seconds from now, which is the
+        // max 'supported' duration of a build. We need that token to be valid for actions done at the end of the build
+        return expiresAt.isBefore(Instant.now().plus(serviceTokenRefreshIfExpiresInSeconds, ChronoUnit.SECONDS));
     }
 }


### PR DESCRIPTION
The logic for the `refreshRequired` method in
`DefaultKeycloakServiceClient` is the reverse of what it should be
returning.

It should be:
- If the token is expiring *before* now + the max duration of the build,
  then we need to renew