### PR TITLE
Downgrade Quarkus to 2.10.4.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
     <pnc-common.version>2.2.0</pnc-common.version>
 
     <surefire-plugin.version>2.22.2</surefire-plugin.version>
-    <quarkus.version>2.12.1.Final</quarkus.version>
+    <quarkus.version>2.10.4.Final</quarkus.version>
     <quarkus-logging-kafka.version>1.0.3</quarkus-logging-kafka.version>
     <resteasy.version>3.6.1.Final</resteasy.version>
     <tagSuffix />


### PR DESCRIPTION
This is the last version that uploads uber jars to Maven Central. The issue with the latest Quarkus version will be fixed in a future release.