### PR TITLE
[NCLSUP-1035] Check if the archive-service-url is set in config

### DIFF
--- a/src/main/java/org/jboss/pnc/cleaner/archiveservice/ArchivesCleanerImpl.java
+++ b/src/main/java/org/jboss/pnc/cleaner/archiveservice/ArchivesCleanerImpl.java
@@ -74,7 +74,7 @@ public class ArchivesCleanerImpl implements ArchivesCleaner {
 
     @Override
     public void deleteArchive(String buildConfigurationId) {
-        if (!Strings.isEmpty(config.getValue("archive-service.delete-api-url", String.class))) {
+        if (config.getOptionalValue("archive-service.delete-api-url", String.class).isPresent()) {
             // Create a parent child span with values from MDC
             SpanBuilder spanBuilder = OtelUtils.buildChildSpan(
                     GlobalOpenTelemetry.get().getTracer(""),


### PR DESCRIPTION
The previous check would throw a SRCFG02004 error as described here: https://quarkus.io/guides/config-reference if the
archive-service.delete-api-url was set to empty in our application.properties.

Instead, we check if it's present and set first by getting the config.getOptionalValue