### PR TITLE
Fix NotAuthorized issues for cleaning up temp builds

### DIFF
--- a/src/main/java/org/jboss/pnc/cleaner/orchApi/OrchClientConfiguration.java
+++ b/src/main/java/org/jboss/pnc/cleaner/orchApi/OrchClientConfiguration.java
@@ -51,7 +51,7 @@ public class OrchClientConfiguration {
     @Inject
     OidcClient oidcClient;
 
-    public Configuration getConfiguration() {
+    public Configuration getConfiguration(boolean authenticated) {
         Configuration.ConfigurationBuilder configurationBuilder = Configuration.builder()
                 .addDefaultMdcToHeadersMappings();
 
@@ -59,8 +59,20 @@ public class OrchClientConfiguration {
         configurationBuilder.host(host);
         configurationBuilder.port(port);
         configurationBuilder.pageSize(pageSize);
-        configurationBuilder.bearerTokenSupplier(() -> oidcClient.getTokens().await().indefinitely().getAccessToken());
+        if (authenticated) {
+            configurationBuilder
+                    .bearerTokenSupplier(() -> oidcClient.getTokens().await().indefinitely().getAccessToken());
+        }
 
         return configurationBuilder.build();
+    }
+
+    /**
+     * By default, we don't want authentication
+     *
+     * @return
+     */
+    public Configuration getConfiguration() {
+        return getConfiguration(false);
     }
 }

--- a/src/main/java/org/jboss/pnc/cleaner/orchApi/OrchClientProducer.java
+++ b/src/main/java/org/jboss/pnc/cleaner/orchApi/OrchClientProducer.java
@@ -42,9 +42,17 @@ public class OrchClientProducer {
         return new BuildClient(orchClientConfiguration.getConfiguration());
     }
 
+    public BuildClient getAuthenticatedBuildClient() {
+        return new BuildClient(orchClientConfiguration.getConfiguration(true));
+    }
+
     @Produces
     public GroupBuildClient getBuildGroupClient() {
         return new GroupBuildClient(orchClientConfiguration.getConfiguration());
+    }
+
+    public GroupBuildClient getAuthenticatedBuildGroupClient() {
+        return new GroupBuildClient(orchClientConfiguration.getConfiguration(true));
     }
 
     @Produces


### PR DESCRIPTION
This happens because we are using an authenticated build client to query through temporary builds that need deletion and if it takes more than 5 minutes, it fails to get a new auth token and fails with NotAuthorized exception.

This fix makes sure that iterating through the endpoint is done anonymously to not have to deal with token renewal.