### PR TITLE
Disable cron concurrent execution

### DIFF
--- a/src/main/java/org/jboss/pnc/cleaner/builds/FailedBuildsCleaner.java
+++ b/src/main/java/org/jboss/pnc/cleaner/builds/FailedBuildsCleaner.java
@@ -139,7 +139,7 @@ public class FailedBuildsCleaner {
         warnCounter = registry.counter(className + ".warning.count");
     }
 
-    @Scheduled(cron = "{failedbuildscleaner.cron}")
+    @Scheduled(cron = "{failedbuildscleaner.cron}", concurrentExecution = Scheduled.ConcurrentExecution.SKIP)
     void cleanRegularly() {
         logger.info("Starting regular failed builds cleanup job.");
         Instant limit = Instant.now().minus(retention, ChronoUnit.HOURS);

--- a/src/main/java/org/jboss/pnc/cleaner/logverifier/BuildLogVerifierScheduler.java
+++ b/src/main/java/org/jboss/pnc/cleaner/logverifier/BuildLogVerifierScheduler.java
@@ -49,7 +49,7 @@ public class BuildLogVerifierScheduler {
     BuildLogVerifier buildLogVerifier;
 
     @Timed
-    @Scheduled(cron = "{buildLogVerifierScheduler.cron}")
+    @Scheduled(cron = "{buildLogVerifierScheduler.cron}", concurrentExecution = Scheduled.ConcurrentExecution.SKIP)
     @WithSpan
     public void verifyBuildLogs() {
         buildLogVerifier.verifyUnflaggedBuilds();

--- a/src/main/java/org/jboss/pnc/cleaner/temporaryBuilds/TemporaryBuildsCleanupScheduler.java
+++ b/src/main/java/org/jboss/pnc/cleaner/temporaryBuilds/TemporaryBuildsCleanupScheduler.java
@@ -41,7 +41,7 @@ public class TemporaryBuildsCleanupScheduler {
     /**
      * Schedules cleanup of old temporary builds
      */
-    @Scheduled(cron = "{temporaryBuildsCleaner.cron}")
+    @Scheduled(cron = "{temporaryBuildsCleaner.cron}", concurrentExecution = Scheduled.ConcurrentExecution.SKIP)
     @WithSpan
     public void cleanupExpiredTemporaryBuilds() {
         log.info("Regular deletion of temporary builds triggered by clock.");


### PR DESCRIPTION
If the first cronjob is so slow that it overlaps with the second cronjob run later, we'll have 2 jobs running in parallel, causing chaos.

This disable the concurrent cron executions to prevent this scenario