### PR TITLE
Disable build-log-verifier

### DIFF
--- a/src/main/java/org/jboss/pnc/cleaner/logverifier/BifrostClient.java
+++ b/src/main/java/org/jboss/pnc/cleaner/logverifier/BifrostClient.java
@@ -21,8 +21,10 @@ import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 import org.jboss.pnc.api.bifrost.rest.Bifrost;
 
 /**
- * @author <a href="mailto:matejonnet@gmail.opecom">Matej Lazar</a>
+ * @author <a href="mailto:matejonnet@gmail.opecom">Matej Lazar</a> We don't need build-log-verifier anymore. Candidate
+ *         for removal
  */
 @RegisterRestClient
+@Deprecated
 public interface BifrostClient extends Bifrost {
 }

--- a/src/main/java/org/jboss/pnc/cleaner/logverifier/BuildLogVerifier.java
+++ b/src/main/java/org/jboss/pnc/cleaner/logverifier/BuildLogVerifier.java
@@ -52,9 +52,11 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * @author <a href="mailto:matejonnet@gmail.com">Matej Lazar</a>
+ * @author <a href="mailto:matejonnet@gmail.com">Matej Lazar</a> We don't need build-log-verifier anymore. Candidate for
+ *         removal
  */
 @ApplicationScoped
+@Deprecated
 public class BuildLogVerifier {
 
     private static final String className = BuildLogVerifier.class.getName();

--- a/src/main/java/org/jboss/pnc/cleaner/logverifier/BuildLogVerifierScheduler.java
+++ b/src/main/java/org/jboss/pnc/cleaner/logverifier/BuildLogVerifierScheduler.java
@@ -41,16 +41,22 @@ import io.quarkus.scheduler.Scheduled;
 import jakarta.inject.Inject;
 
 /**
- * @author <a href="mailto:matejonnet@gmail.com">Matej Lazar</a>
+ * @author <a href="mailto:matejonnet@gmail.com">Matej Lazar</a> We don't need build-log-verifier anymore. Candidate for
+ *         removal
  */
+@Deprecated
 public class BuildLogVerifierScheduler {
 
     @Inject
     BuildLogVerifier buildLogVerifier;
 
+    /**
+     * We don't need build-log-verifier anymore. Candidate for removal
+     */
     @Timed
     @Scheduled(cron = "{buildLogVerifierScheduler.cron}", concurrentExecution = Scheduled.ConcurrentExecution.SKIP)
     @WithSpan
+    @Deprecated
     public void verifyBuildLogs() {
         buildLogVerifier.verifyUnflaggedBuilds();
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -50,8 +50,9 @@ temporaryBuildsCleaner.lifespan=14
 temporaryBuildsCleaner.cron=0 15 0 ? * Sun
 
 #Build Log Verifier
-#run every 15 min
-buildLogVerifierScheduler.cron=0 */15 * ? * *
+# Deprecated
+#run every 15 min from year 1970, effectively disabling it
+buildLogVerifierScheduler.cron=0 */15 * ? * * 1970
 buildLogVerifierScheduler.maxRetries=5
 %test.buildLogVerifierScheduler.maxRetries=1
 


### PR DESCRIPTION
Deprecating its classes since it's not needed anymore, with the live-logs and the final-logs not matching anymore.

It can still be activated again by adjusting the cron configuration, or we go back to year 1970, whichever is easier :)